### PR TITLE
Muchisimos cambios leer commits

### DIFF
--- a/QuackEngineSol/Src/CEGUI/CEGUIQuack.cpp
+++ b/QuackEngineSol/Src/CEGUI/CEGUIQuack.cpp
@@ -28,7 +28,7 @@ void CEGUIQuack::setUp(Ogre::RenderWindow* rWindow)
 	CEGUI::System::getSingleton().getDefaultGUIContext().getMouseCursor().setDefaultImage("TaharezLook/MouseArrow");
 
 	CEGUI::Window* myRoot = CEGUI::WindowManager::getSingleton().createWindow("DefaultWindow", "_MasterRoot");
-	myRoot->setUsingAutoRenderingSurface(true);	
+	myRoot->setUsingAutoRenderingSurface(true);
 	CEGUI::System::getSingleton().getDefaultGUIContext().setRootWindow(myRoot);
 
 	setUpResources();
@@ -63,7 +63,7 @@ void CEGUIQuack::setFont(std::string filename)
 
 
 CEGUI::Window* CEGUIQuack::createWidget(std::string type, std::string name, std::pair<float, float> pos, std::pair<float, float> size)
-{	
+{
 	CEGUI::Window* myImageWindow = CEGUI::WindowManager::getSingleton().createWindow(type, name);
 	myImageWindow->setPosition(CEGUI::UVector2(CEGUI::UDim(pos.first, 0.0), CEGUI::UDim(pos.second, 0.0)));
 	myImageWindow->setSize(CEGUI::USize(CEGUI::UDim(0.0, size.first), CEGUI::UDim(0.0, size.second)));
@@ -74,35 +74,49 @@ CEGUI::Window* CEGUIQuack::createWidget(std::string type, std::string name, std:
 }
 
 
-void CEGUIQuack::createButton(std::string name, std::string text, std::pair<float, float> pos, std::pair<float, float> size, std::function<void()>func,std::string style)
+CEGUI::Window* CEGUIQuack::createButton(std::string name, std::string text, std::pair<float, float> pos, std::pair<float, float> size, std::function<void()>func, std::string style)
 {
 	CEGUI::Window* newWidget = nullptr;
-	try	{ newWidget = createWidget(style, name, pos, size);	}
+	try { newWidget = createWidget(style, name, pos, size); }
 	catch (std::exception e) { std::cout << "No se ha podido crear el boton: " << name << "\n"; }
 
 
-	
+
 	newWidget->subscribeEvent(CEGUI::PushButton::EventClicked, func);
 	newWidget->setText(text);
+
+	return newWidget;
 }
 
-void CEGUIQuack::createText(std::string name, std::string text, std::pair<float, float> pos, std::pair<float, float> size,std::string style)
+CEGUI::Window* CEGUIQuack::createText(std::string name, std::string text, std::pair<float, float> pos, std::pair<float, float> size, std::string style)
 {
 	CEGUI::Window* newWidget = nullptr;
 	try { newWidget = createWidget(style, name, pos, size); }
 	catch (std::exception e) { std::cout << "No se ha podido crear el texto: " << name << "\n"; }
 
 	newWidget->setProperty("Text", text);
+
+	return newWidget;
 }
 
-void CEGUIQuack::createImage(std::string name, std::string image, std::pair<float, float> pos, std::pair<float, float> size,std::string style)
+CEGUI::Window* CEGUIQuack::createImage(std::string name, std::string image, std::pair<float, float> pos, std::pair<float, float> size, std::string style)
 {
 	CEGUI::Window* newWidget = nullptr;
 	try { newWidget = createWidget(style, name, pos, size); }
 	catch (std::exception e) { std::cout << "No se ha podido crear la imagen: " << name << "\n"; }
 
-	CEGUI::ImageManager::getSingleton().addFromImageFile(name, image);
+	if (!CEGUI::ImageManager::getSingleton().isDefined(name))
+		CEGUI::ImageManager::getSingleton().addFromImageFile(name, image);
+
 	newWidget->setProperty("Image", name);
+
+	return newWidget;
+}
+
+void CEGUIQuack::removeWidget(CEGUI::Window* window)
+{
+	CEGUI::System::getSingleton().getDefaultGUIContext().getRootWindow()->removeChild(window);
+	//CEGUI::WindowManager::getSingleton().destroyWindow(window);
 }
 
 

--- a/QuackEngineSol/Src/CEGUI/CEGUIQuack.h
+++ b/QuackEngineSol/Src/CEGUI/CEGUIQuack.h
@@ -60,9 +60,11 @@ public:
 	void loadScheme(std::string filename);
 	void setFont(std::string filename);
 	
-	void createButton(std::string name, std::string text, std::pair<float, float> pos, std::pair<float, float> size, std::function<void()>func,std::string style);
-	void createText(std::string name, std::string text, std::pair<float, float> pos, std::pair<float, float> size, std::string style);
-	void createImage(std::string name, std::string image, std::pair<float, float> pos, std::pair<float, float> size,std::string style);
+	CEGUI::Window* createButton(std::string name, std::string text, std::pair<float, float> pos, std::pair<float, float> size, std::function<void()>func,std::string style);
+	CEGUI::Window* createText(std::string name, std::string text, std::pair<float, float> pos, std::pair<float, float> size, std::string style);
+	CEGUI::Window* createImage(std::string name, std::string image, std::pair<float, float> pos, std::pair<float, float> size,std::string style);
+
+	void removeWidget(CEGUI::Window* window);
 	
 };
 

--- a/QuackEngineSol/Src/GameExample/Game.cpp
+++ b/QuackEngineSol/Src/GameExample/Game.cpp
@@ -11,7 +11,7 @@ int WINAPI
 WinMain(HINSTANCE zHInstance, HINSTANCE prevInstance, LPSTR lpCmdLine, int nCmdShow) {
 #endif
 	// AQUI FALTA MANEJO DE ERRORES Y EXCEPCIONES
-	if (QuackEnginePro::Init()) {
+	if (QuackEnginePro::Init("Juego de Prueba to Guapo")) {
 
 		QuackEnginePro::Instance()->start("Scenes/scene1.lua", "scene1");
 	}

--- a/QuackEngineSol/Src/OGRE/OgreQuack.cpp
+++ b/QuackEngineSol/Src/OGRE/OgreQuack.cpp
@@ -12,9 +12,9 @@ using namespace Ogre;
 std::unique_ptr<OgreQuack>  OgreQuack::instance_;
 
 // AQUI FALTA MANEJO DE ERRORES Y EXCEPCIONES (no, no?)
-bool OgreQuack::Init() {
+bool OgreQuack::Init(std::string name) {
 	assert(instance_.get() == nullptr);
-	instance_.reset(new OgreQuack());
+	instance_.reset(new OgreQuack(name));
 	return instance_.get();
 }
 
@@ -63,7 +63,7 @@ void OgreQuack::setupWindow()
 
 	Uint32 flags = SDL_WINDOW_ALLOW_HIGHDPI; //SDL_WINDOW_RESIZABLE
 
-	sdlWindow_ = SDL_CreateWindow("ventana to guapa", SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, screen_width_, screen_height_, flags);
+	sdlWindow_ = SDL_CreateWindow(name_.c_str(), SDL_WINDOWPOS_UNDEFINED, SDL_WINDOWPOS_UNDEFINED, screen_width_, screen_height_, flags);
 
 	SDL_SysWMinfo wmInfo;
 	SDL_VERSION(&wmInfo.version);
@@ -79,7 +79,7 @@ void OgreQuack::setupWindow()
 
 	params["externalWindowHandle"] = Ogre::StringConverter::toString(size_t(wmInfo.info.win.window));
 
-	window_ = mRoot_->createRenderWindow("ventana to guapa", screen_width_, screen_height_, false, &params);
+	window_ = mRoot_->createRenderWindow(name_.c_str(), screen_width_, screen_height_, false, &params);
 
 	SDL_SetWindowGrab(sdlWindow_, SDL_bool(false));
 	SDL_ShowCursor(false);

--- a/QuackEngineSol/Src/OGRE/OgreQuack.h
+++ b/QuackEngineSol/Src/OGRE/OgreQuack.h
@@ -29,6 +29,8 @@ private:
 
 	SDL_Window* sdlWindow_;
 
+	std::string name_;
+
 	int screen_width_ = 1000;
 
 	int screen_height_ = 700;
@@ -39,12 +41,12 @@ private:
 
 public:
 
-	static bool Init();
+	static bool Init(std::string name);
 
 	// devuelve puntero al singleton
 	static OgreQuack* Instance();
 
-	OgreQuack() {
+	OgreQuack(std::string name): name_(name) {
 		setupRoot();
 	}
 

--- a/QuackEngineSol/Src/QuackEngine/Light.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Light.cpp
@@ -3,6 +3,7 @@
 #include "Transform.h"
 #include <OgreLight.h>
 #include <OgreSceneNode.h>
+#include <OgreSceneManager.h>
 
 
 Light::Light() :
@@ -13,7 +14,7 @@ Light::Light() :
 
 Light::~Light()
 {
-	delete light_;
+	OgreQuack::Instance()->getSceneManager()->destroyLight(light_);
 	light_ = nullptr;
 }
 

--- a/QuackEngineSol/Src/QuackEngine/Prueba.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Prueba.cpp
@@ -33,14 +33,6 @@ bool Prueba::init(luabridge::LuaRef parameterTable)
 
 void Prueba::start()
 {
-	if (entity_->getComponent<Rigidbody>()) {
-		QuackEntity* e = new QuackEntity();
-		e->transform()->setGlobalPosition({ 2, 10, 0 });
-		e->addComponent<MeshRenderer>()->setMeshByPrefab(PT_CUBE);
-		e->addComponent<Rigidbody>()->setRigidbody(1, CT_BOX);
-		SceneMng::Instance()->getCurrentScene()->addEntity(e);
-		//entity_->getComponent<Rigidbody>()->setGravity(Vector3D());
-	}
 }
 
 void Prueba::fixedUpdate()
@@ -72,8 +64,8 @@ void Prueba::onCollisionEnter(QuackEntity* other, Vector3D point)
 {
 	//entity_->getComponent<Rigidbody>()->addForce(Vector3D(0, 10, 0), IMPULSE);
 	
-	std::string carga = "Scenes/" + valor3 + ".lua";
-	SceneMng::Instance()->loadScene(carga, valor3);
+	/*std::string carga = "Scenes/" + valor3 + ".lua";
+	SceneMng::Instance()->pushNewScene(carga, valor3);*/
 	std::cout << "Yo " << entity_->name() << " acabo de chocar con " << other->name() << "\n\n";
 }
 

--- a/QuackEngineSol/Src/QuackEngine/Prueba.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Prueba.cpp
@@ -55,7 +55,7 @@ void Prueba::update()
 {
 	scalealgo += QuackEnginePro::Instance()->time()->deltaTime();
 
-	transform->setScale({ abs(sin(scalealgo)),abs(sin(scalealgo)),abs(sin(scalealgo)) });
+	//transform->setScale({ abs(sin(scalealgo)),abs(sin(scalealgo)),abs(sin(scalealgo)) });
 	/*transform->Translate(Vector3D(0, -1, 0) * QuackEnginePro::Instance()->time()->deltaTime());
 	transform->Rotate(Vector3D(45, 0, 90) * QuackEnginePro::Instance()->time()->deltaTime());*/
 	//if (transform->globalPosition().y < -10) {
@@ -71,6 +71,9 @@ void Prueba::update()
 void Prueba::onCollisionEnter(QuackEntity* other, Vector3D point)
 {
 	//entity_->getComponent<Rigidbody>()->addForce(Vector3D(0, 10, 0), IMPULSE);
+	
+	std::string carga = "Scenes/" + valor3 + ".lua";
+	SceneMng::Instance()->loadScene(carga, valor3);
 	std::cout << "Yo " << entity_->name() << " acabo de chocar con " << other->name() << "\n\n";
 }
 

--- a/QuackEngineSol/Src/QuackEngine/Prueba.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Prueba.cpp
@@ -45,12 +45,17 @@ void Prueba::start()
 
 void Prueba::fixedUpdate()
 {
+
+
 	//std::cout << transform->rotation() << "\n";
 	//entity_->getComponent<Rigidbody>()->addTorque({ 0,1,0 });
 }
 
 void Prueba::update()
 {
+	scalealgo += QuackEnginePro::Instance()->time()->deltaTime();
+
+	transform->setScale({ abs(sin(scalealgo)),abs(sin(scalealgo)),abs(sin(scalealgo)) });
 	/*transform->Translate(Vector3D(0, -1, 0) * QuackEnginePro::Instance()->time()->deltaTime());
 	transform->Rotate(Vector3D(45, 0, 90) * QuackEnginePro::Instance()->time()->deltaTime());*/
 	//if (transform->globalPosition().y < -10) {

--- a/QuackEngineSol/Src/QuackEngine/Prueba.h
+++ b/QuackEngineSol/Src/QuackEngine/Prueba.h
@@ -7,6 +7,7 @@ private:
 	int valor1;
 	int* valor2;
 	std::string valor3;
+	float scalealgo = 0;
 
 public:
 	Prueba(QuackEntity* e = nullptr);

--- a/QuackEngineSol/Src/QuackEngine/QuackCamera.cpp
+++ b/QuackEngineSol/Src/QuackEngine/QuackCamera.cpp
@@ -11,6 +11,14 @@ QuackCamera::QuackCamera(QuackEntity* e) : Component(e), camera_(nullptr)
 
 QuackCamera::~QuackCamera()
 {
+	mSM_->destroyCamera(camera_);
+	window_->removeViewport(vp_->getZOrder());
+	camera_ = nullptr;
+	node_ = nullptr;
+	mSM_ = nullptr;
+	window_ = nullptr;
+	vp_ = nullptr;
+
 }
 
 bool QuackCamera::init(luabridge::LuaRef parameterTable)

--- a/QuackEngineSol/Src/QuackEngine/QuackEnginePro.cpp
+++ b/QuackEngineSol/Src/QuackEngine/QuackEnginePro.cpp
@@ -175,8 +175,7 @@ void QuackEnginePro::pollEvents()
 			break;
 		default:
 			InputManager::Instance()->ManageInput(event);
-			if (InputManager::Instance()->isKeyDown(SDL_SCANCODE_SPACE)) std::cout << "Pos raton x: " << InputManager::Instance()->getMousePositionRelative().x << " y " << InputManager::Instance()->getMousePositionRelative().x << "\n";
-			std::cout << "eje x: " << InputManager::Instance()->getAxis(Axis::Horizontal)<< " , " << "eje Y: " << InputManager::Instance()->getAxis(Axis::Vertical) << "\n";
+			//if (InputManager::Instance()->isKeyDown(SDL_SCANCODE_SPACE)) std::cout << "Pos raton x: " << InputManager::Instance()->getMousePositionRelative().x << " y " << InputManager::Instance()->getMousePositionRelative().x << "\n";
 			break;
 		}
 	}

--- a/QuackEngineSol/Src/QuackEngine/QuackEnginePro.cpp
+++ b/QuackEngineSol/Src/QuackEngine/QuackEnginePro.cpp
@@ -69,14 +69,14 @@ bool QuackEnginePro::Init(std::string name)
 QuackEnginePro* QuackEnginePro::Instance()
 {
 	assert(instance_.get() != nullptr);
-	
+
 	return instance_.get();
 }
 
 void QuackEnginePro::setup()
 {
 	readAssetsRoute();
-	
+
 	OgreQuack::Init(windowName);
 
 	ResourceMng::Init(assets_route);
@@ -96,7 +96,7 @@ void QuackEnginePro::setup()
 	CEGUIQuack::Instance()->setUp(OgreQuack::Instance()->getWindow());
 
 	CallBacks::Init();
-	
+
 	SceneMng::Init();
 
 	InputManager::Init();
@@ -131,7 +131,6 @@ void QuackEnginePro::update()
 		pollEvents();
 
 		if (fixedTime > FIXED_TIME_UPDATE) {
-			std::cout << "Fixed" << std::endl;
 			SceneMng::Instance()->fixedUpdate();
 			fixedTime = 0;
 		}
@@ -141,9 +140,11 @@ void QuackEnginePro::update()
 		OgreQuack::Instance()->getRoot()->renderOneFrame();
 
 		SceneMng::Instance()->lateUpdate();
-		
-		SceneMng::Instance()->lastUpdate();
-		CEGUIQuack::Instance()->render(time()->deltaTime());
+
+		//CEGUIQuack::Instance()->render(time()->deltaTime());
+
+		if (!SceneMng::Instance()->lastUpdate())
+			exit = true;
 	}
 
 #if (defined _DEBUG) || !(defined _WIN32)

--- a/QuackEngineSol/Src/QuackEngine/QuackEnginePro.cpp
+++ b/QuackEngineSol/Src/QuackEngine/QuackEnginePro.cpp
@@ -57,15 +57,12 @@ QuackEnginePro::~QuackEnginePro() {
 	delete quackTime_;	quackTime_ = nullptr;
 };
 
-bool QuackEnginePro::Init()
+bool QuackEnginePro::Init(std::string name)
 {
 	_CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
-#if (defined _DEBUG) && (defined _WIN32)
-	int* a = new int();		// para que estemos seguros de que siempre se estan viendo los memory leaks
-#endif
 
 	assert(instance_.get() == nullptr);
-	instance_.reset(new QuackEnginePro());
+	instance_.reset(new QuackEnginePro(name));
 	return instance_.get();
 }
 
@@ -80,7 +77,7 @@ void QuackEnginePro::setup()
 {
 	readAssetsRoute();
 	
-	OgreQuack::Init();
+	OgreQuack::Init(windowName);
 
 	ResourceMng::Init(assets_route);
 	ResourceMng::Instance()->setup(); //Carga de recursos
@@ -134,6 +131,7 @@ void QuackEnginePro::update()
 		pollEvents();
 
 		if (fixedTime > FIXED_TIME_UPDATE) {
+			std::cout << "Fixed" << std::endl;
 			SceneMng::Instance()->fixedUpdate();
 			fixedTime = 0;
 		}

--- a/QuackEngineSol/Src/QuackEngine/QuackEnginePro.h
+++ b/QuackEngineSol/Src/QuackEngine/QuackEnginePro.h
@@ -31,6 +31,8 @@ private:
 	
 	std::string assets_route = "";
 
+	std::string windowName;
+
 	SDL_Window* sdlWindow_;
 
 	QuackTime* quackTime_;
@@ -57,13 +59,13 @@ private:
 
 public:
 
-	QuackEnginePro() {
+	QuackEnginePro(std::string name): windowName(name) {
 		setup();
 	}
 
 	~QuackEnginePro();
 
-	static bool Init();
+	static bool Init(std::string name = "PONLE UN NOMBRE A LA VENTANA EN EL INIT");
 
 	static QuackEnginePro* Instance();
 

--- a/QuackEngineSol/Src/QuackEngine/QuackEnginePro.h
+++ b/QuackEngineSol/Src/QuackEngine/QuackEnginePro.h
@@ -22,13 +22,13 @@ class ResourceMng;
 class InputManager;
 
 const int NFrames = 50;
-const float FIXED_TIME_UPDATE = 1.0f/NFrames;
+const float FIXED_TIME_UPDATE = 1.0f / NFrames;
 
 class QUACK_ENGINE_PRO_API QuackEnginePro {
 private:
 
 	static std::unique_ptr<QuackEnginePro> instance_;
-	
+
 	std::string assets_route = "";
 
 	std::string windowName;
@@ -52,14 +52,14 @@ private:
 	bool exit = true;
 
 	float fixedTime = 0;
-	
+
 	static void pruebaBotonCallback();
 
 	void readAssetsRoute();
 
 public:
 
-	QuackEnginePro(std::string name): windowName(name) {
+	QuackEnginePro(std::string name) : windowName(name) {
 		setup();
 	}
 
@@ -74,6 +74,8 @@ public:
 	void start(std::string route, std::string name);
 
 	QuackTime* time();
+
+	void quit() { exit = true; }
 
 };
 

--- a/QuackEngineSol/Src/QuackEngine/QuackEntity.cpp
+++ b/QuackEngineSol/Src/QuackEngine/QuackEntity.cpp
@@ -46,6 +46,7 @@ Component* QuackEntity::addComponent(const std::string& componentName, LuaRef pa
 {
 	if (componentName == "Transform") {
 		transform_->init(param);
+		transform_->transform = transform_;
 		return transform_;
 	}
 	else if (hasComponent(componentName)) //para no repetir componentes
@@ -62,8 +63,8 @@ Component* QuackEntity::addComponent(const std::string& componentName, LuaRef pa
 		cmpMap_.insert({ componentName , c });
 		cmpMap_[componentName] = c; //sin esta linea, el map guarda null por alg�n motivo
 
-		//if(componente enable)																// TODO GUARDAR SI EL COMPONENTE ESTÁ ENABLE
-		c->onEnable();
+		if (c->isEnable() && active_)																// TODO GUARDAR SI EL COMPONENTE ESTÁ ENABLE
+			c->onEnable();
 
 		return c;
 	}

--- a/QuackEngineSol/Src/QuackEngine/Rigidbody.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Rigidbody.cpp
@@ -150,6 +150,7 @@ void Rigidbody::resetTransform()
 	tr.setRotation(transform->rotation().toBulletRotation());
 
 	rb_->setWorldTransform(tr);
+	rb_->getCollisionShape()->setLocalScaling(Vector3D::toBullet(transform->localScale()));
 	rb_->getMotionState()->setWorldTransform(tr);
 }
 

--- a/QuackEngineSol/Src/QuackEngine/Rigidbody.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Rigidbody.cpp
@@ -159,7 +159,7 @@ float Rigidbody::getMass()
 	return rb_->getMass();
 }
 
-void Rigidbody::addForce(Vector3D force, ForceMode mode, bool local)
+void Rigidbody::addForce(Vector3D force, ForceMode mode)
 {
 	if (mode)
 		rb_->applyCentralImpulse(force.toBulletPosition());
@@ -167,7 +167,7 @@ void Rigidbody::addForce(Vector3D force, ForceMode mode, bool local)
 		rb_->applyCentralForce(force.toBulletPosition());
 }
 
-void Rigidbody::addTorque(Vector3D force, ForceMode mode, bool local)
+void Rigidbody::addTorque(Vector3D force, ForceMode mode)
 {
 	if (mode)
 		rb_->applyTorque(force.toBulletPosition());

--- a/QuackEngineSol/Src/QuackEngine/Rigidbody.h
+++ b/QuackEngineSol/Src/QuackEngine/Rigidbody.h
@@ -98,9 +98,9 @@ public:
 
 	float getMass();
 
-	void addForce(Vector3D force, ForceMode mode = FORCE, bool local = false);
+	void addForce(Vector3D force, ForceMode mode = FORCE);
 
-	void addTorque(Vector3D force, ForceMode mode = FORCE, bool local = false);
+	void addTorque(Vector3D force, ForceMode mode = FORCE);
 
 	void clearForce();
 

--- a/QuackEngineSol/Src/QuackEngine/Scene.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Scene.cpp
@@ -80,19 +80,19 @@ bool Scene::createUI(luabridge::LuaRef info)
 		}
 		else if (type == "Text")
 		{
-			CEGUIQuack::Instance()->createText(name, readVariable<std::string>(cmpInfo, "Text"),
-				{ pos[1],pos[2] }, { size[1], size[2] }, readVariable<std::string>(cmpInfo, "Style"));
+			uiEntities_.push_back(CEGUIQuack::Instance()->createText(name, readVariable<std::string>(cmpInfo, "Text"),
+				{ pos[1],pos[2] }, { size[1], size[2] }, readVariable<std::string>(cmpInfo, "Style")));
 		}
 		else if (type == "Image")
 		{
-			CEGUIQuack::Instance()->createImage(name, readVariable<std::string>(cmpInfo, "Image"),
-				{ pos[1],pos[2] }, { size[1], size[2] }, readVariable<std::string>(cmpInfo, "Style"));
+			uiEntities_.push_back(CEGUIQuack::Instance()->createImage(name, readVariable<std::string>(cmpInfo, "Image"),
+				{ pos[1],pos[2] }, { size[1], size[2] }, readVariable<std::string>(cmpInfo, "Style")));
 		}
 		else if (type == "Button")
 		{
-			CEGUIQuack::Instance()->createButton(name, readVariable<std::string>(cmpInfo, "Text"),
+			uiEntities_.push_back(CEGUIQuack::Instance()->createButton(name, readVariable<std::string>(cmpInfo, "Text"),
 				{ pos[1],pos[2] }, { size[1], size[2] }, CallBacks::instance()->getMethod(
-					readVariable<std::string>(cmpInfo, "CallBackFunction")), readVariable<std::string>(cmpInfo, "Style"));
+					readVariable<std::string>(cmpInfo, "CallBackFunction")), readVariable<std::string>(cmpInfo, "Style")));
 		}
 	}
 	//tan solo tenemos 3 tipos de elementos de ui
@@ -106,6 +106,12 @@ Scene::~Scene()
 	for (QuackEntity* qEnt : entities_) {
 		delete qEnt;
 		qEnt = nullptr;
+	}
+
+	for (CEGUI::Window* w : uiEntities_) {
+		CEGUIQuack::Instance()->removeWidget(w);
+		delete w;
+		w = nullptr;
 	}
 }
 

--- a/QuackEngineSol/Src/QuackEngine/Scene.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Scene.cpp
@@ -52,7 +52,7 @@ bool Scene::createEntity(const std::string& fileName, LuaRef entInfo)
 		entity->addComponent(components[i], entInfo.rawget(components[i]));
 	}
 
-	entity->setActive(true);						// COMPROBAR SI EST� AC
+	entity->setActive(readVariable<bool>(entInfo, "Active"));
 
 	addEntity(entity);
 
@@ -80,7 +80,7 @@ bool Scene::createUI(luabridge::LuaRef info)
 		}
 		else if (type == "Text")
 		{
-			CEGUIQuack::Instance()->createText(name,readVariable<std::string>(cmpInfo, "Text"),
+			CEGUIQuack::Instance()->createText(name, readVariable<std::string>(cmpInfo, "Text"),
 				{ pos[1],pos[2] }, { size[1], size[2] }, readVariable<std::string>(cmpInfo, "Style"));
 		}
 		else if (type == "Image")
@@ -92,8 +92,7 @@ bool Scene::createUI(luabridge::LuaRef info)
 		{
 			CEGUIQuack::Instance()->createButton(name, readVariable<std::string>(cmpInfo, "Text"),
 				{ pos[1],pos[2] }, { size[1], size[2] }, CallBacks::instance()->getMethod(
-				readVariable<std::string>(cmpInfo, "CallBackFunction")), readVariable<std::string>(cmpInfo, "Style"));
-
+					readVariable<std::string>(cmpInfo, "CallBackFunction")), readVariable<std::string>(cmpInfo, "Style"));
 		}
 	}
 	//tan solo tenemos 3 tipos de elementos de ui
@@ -196,6 +195,27 @@ void Scene::clearEntities()
 		else
 			it++;
 	}
+}
+
+QuackEntity* Scene::getObjectWithName(std::string name)
+{
+	for (QuackEntity* e : entities_) {
+		if (e->name() == name)
+			return e;
+	}
+	return nullptr;
+}
+
+std::vector<QuackEntity*> Scene::getAllObjectsWithName(std::string name)
+{
+	std::vector<QuackEntity*> eS = std::vector<QuackEntity*>();
+
+	for (QuackEntity* e : entities_) {
+		if (e->name() == name)
+			eS.push_back(e);
+	}
+
+	return eS;
 }
 
 void Scene::callBackBoton()

--- a/QuackEngineSol/Src/QuackEngine/Scene.h
+++ b/QuackEngineSol/Src/QuackEngine/Scene.h
@@ -16,11 +16,17 @@ namespace luabridge {
 	class LuaRef;
 }
 
+namespace CEGUI
+{
+	class Window;
+}
+
 
 class QUACK_ENGINE_PRO_API Scene
 {
 private:
 	std::vector<QuackEntity*> entities_;
+	std::vector<CEGUI::Window*> uiEntities_;
 
 	bool createEntity(const std::string& fileName, luabridge::LuaRef entInfo);
 

--- a/QuackEngineSol/Src/QuackEngine/Scene.h
+++ b/QuackEngineSol/Src/QuackEngine/Scene.h
@@ -50,6 +50,20 @@ public:
 
 	void lastUpdate();
 
+	/// <summary>
+	/// Busca y devuelve el primer objeto en la escena con ese nombre
+	/// </summary>
+	/// <param name="name">Nombre del objeto a buscar</param>
+	/// <returns>Primer objeto en la escena con ese nombre</returns>
+	QuackEntity* getObjectWithName(std::string name);
+
+	/// <summary>
+	/// Busca y devuelve una lista con los objetos con el nombre indicado
+	/// </summary>
+	/// <param name="name">Nombre de los objetos a buscar</param>
+	/// <returns>Lista de objetos con ese nombre en la escena</returns>
+	std::vector<QuackEntity*> getAllObjectsWithName(std::string name);
+
 	static void callBackBoton();
 
 };

--- a/QuackEngineSol/Src/QuackEngine/Scene.h
+++ b/QuackEngineSol/Src/QuackEngine/Scene.h
@@ -28,7 +28,7 @@ private:
 	std::vector<QuackEntity*> entities_;
 	std::vector<CEGUI::Window*> uiEntities_;
 
-	bool createEntity(const std::string& fileName, luabridge::LuaRef entInfo);
+	QuackEntity* createEntity(const std::string& fileName, luabridge::LuaRef entInfo);
 
 	bool createUI(luabridge::LuaRef info);
 

--- a/QuackEngineSol/Src/QuackEngine/SceneMng.h
+++ b/QuackEngineSol/Src/QuackEngine/SceneMng.h
@@ -8,7 +8,7 @@
 #  endif
 #endif
 
-#include <queue>
+#include <stack>
 
 #include "Scene.h"
 
@@ -17,7 +17,18 @@ class QUACK_ENGINE_PRO_API SceneMng
 private:
 	static std::unique_ptr<SceneMng> instance_;
 	
-	std::queue<Scene*> sceneQueue_;
+	std::stack<Scene*> sceneStack_;
+
+	bool popScene_ = false;
+
+	bool loadScene_ = false;
+
+	bool pushScene_ = false;
+
+	std::string sceneToLoad_ = "";
+	std::string sceneName_ = "";
+
+	void clearScenes();
 
 public:
 
@@ -28,13 +39,15 @@ public:
 	~SceneMng();
 
 	void loadScene(std::string file, std::string sceneName);
+	void pushNewScene(std::string file, std::string sceneName);
+	void popCurrentScene();
 
 	void preUpdate();
 	void physicsUpdate();
 	void fixedUpdate();
 	void update();
 	void lateUpdate();
-	void lastUpdate();
+	bool lastUpdate();
 
 	Scene* getCurrentScene();
 };


### PR DESCRIPTION
- Arreglado el scale que hacía cosas raras con el rigidbody al cambiarse en ejecución
- Ajustado el orden de llamada al onEnable de los objetos para evitar llamarlo antes de que una escena se termine de generar
- Ajustado el orden de llamada del onEnable de los componentes para evitar que se llamen a mitad de generación de un objeto
- Manejo completo de la basura, necesario para poder cambiar de escena y evitar que Ogre detecte objetos duplicados.
- Añadida la posibilidad de elegir el nombre de la ventana del juego al iniciar el motor
![image](https://user-images.githubusercontent.com/55288550/118569862-18363c00-b77b-11eb-9703-46d7ba7aa989.png)

- Las entidades cuando se cargan por Lua se les puede poner delante si quieres que empiece desactivadas 
![image](https://user-images.githubusercontent.com/55288550/118569548-7878ae00-b77a-11eb-90d9-985568870347.png)

- Posibilidad de usar un "Find" para encontrar objetos en la escena por su nombre 
![image](https://user-images.githubusercontent.com/55288550/118569643-9ba35d80-b77a-11eb-8bef-021af2440a42.png)

- Ya se puede cargar una escena nueva con el método loadScene, de momento elimina la escena antigua y carga la nueva. Los métodos  pushNewScene y popCurrentScene no funcionan correctamente a la espera de ajustar una cosa de los viewports
![image](https://user-images.githubusercontent.com/55288550/118570079-9eeb1900-b77b-11eb-943b-49d2f025d105.png)

- Carga de Hijos por Lua. Se guardan dentro del archivo de Lua en una zona al final de la definición de la entidad padre, dando una estructura de cascada. No es necesario añadir Children a los objetos en lua si no tienen hijos.
![image](https://user-images.githubusercontent.com/55288550/118570221-01dcb000-b77c-11eb-81dd-3fec4f4c90ce.png)




