### PR TITLE
Metodos angularVelocity y setAngularVelocity

### DIFF
--- a/QuackEngineSol/Src/QuackEngine/Prueba.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Prueba.cpp
@@ -51,6 +51,8 @@ void Prueba::fixedUpdate()
 
 void Prueba::update()
 {
+	if (entity_->getComponent<Rigidbody>())
+		entity_->getComponent<Rigidbody>()->setAngularVelocity({ 0,1,0 });
 	//if (InputManager::Instance()->getKey(SDL_SCANCODE_SPACE))
 	//	std::cout << "Espacio mantenido\n";
 	//if (InputManager::Instance()->getKeyDown(SDL_SCANCODE_L)) {

--- a/QuackEngineSol/Src/QuackEngine/Rigidbody.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Rigidbody.cpp
@@ -210,12 +210,12 @@ void Rigidbody::setVelocity(Vector3D v)
 
 Vector3D Rigidbody::angularVelocity()
 {
-	return Vector3D::fromBulletPosition(rb_->getAngularVelocity());
+	return Vector3D::fromBullet(rb_->getAngularVelocity());
 }
 
 void Rigidbody::setAngularVelocity(Vector3D v)
 {
-	rb_->setAngularVelocity(v.toBulletPosition());
+	rb_->setAngularVelocity(v.toBullet());
 }
 
 void Rigidbody::setPositionConstrains(bool x, bool y, bool z)

--- a/QuackEngineSol/Src/QuackEngine/Rigidbody.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Rigidbody.cpp
@@ -208,6 +208,16 @@ void Rigidbody::setVelocity(Vector3D v)
 	rb_->setLinearVelocity(v.toBulletPosition());
 }
 
+Vector3D Rigidbody::angularVelocity()
+{
+	return Vector3D::fromBulletPosition(rb_->getAngularVelocity());
+}
+
+void Rigidbody::setAngularVelocity(Vector3D v)
+{
+	rb_->setAngularVelocity(v.toBulletPosition());
+}
+
 void Rigidbody::setPositionConstrains(bool x, bool y, bool z)
 {
 	positionConstrains_ = Vector3D(x, y, z);
@@ -226,7 +236,6 @@ void Rigidbody::removeCollisionData(Rigidbody* rb)
 			it++;
 	}
 }
-
 
 void Rigidbody::setRotationConstrains(bool x, bool y, bool z)
 {

--- a/QuackEngineSol/Src/QuackEngine/Rigidbody.h
+++ b/QuackEngineSol/Src/QuackEngine/Rigidbody.h
@@ -114,6 +114,10 @@ public:
 
 	void setVelocity(Vector3D v);
 
+	Vector3D angularVelocity();
+
+	void setAngularVelocity(Vector3D v);
+
 	void setRotationConstrains(bool x , bool y, bool z);
 
 	void setPositionConstrains(bool x, bool y, bool z);

--- a/QuackEngineSol/Src/QuackEngine/Vector3D.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Vector3D.cpp
@@ -80,6 +80,16 @@ btQuaternion Vector3D::toBulletRotation()
 	return q;
 }
 
+btVector3 Vector3D::toBullet()
+{
+	return btVector3(this->x, this->y, this->z);
+}
+
+Ogre::Vector3 Vector3D::toOgre()
+{
+	return Ogre::Vector3(this->x, this->y, this->z);
+}
+
 Ogre::Vector3 Vector3D::toOgre(Vector3D v)
 {
 	return Ogre::Vector3(v.x, v.y, v.z);

--- a/QuackEngineSol/Src/QuackEngine/Vector3D.h
+++ b/QuackEngineSol/Src/QuackEngine/Vector3D.h
@@ -76,6 +76,10 @@ public:
 
 	btQuaternion toBulletRotation();
 
+	btVector3 toBullet();
+
+	Ogre::Vector3 toOgre();
+
 	static Vector3D up() { return { 0,1,0 }; }
 
 	static Vector3D rigth() { return { 1,0,0 }; }


### PR DESCRIPTION
Añadidos al componente Rigidbody los métodos angularVelocity y setAngularVelocity equivalentes a velocity y setVelocity para trabajar mejor con giros.