### PR TITLE
Carga de prefabs desde código

### DIFF
--- a/QuackEngineSol/Src/LuaBridge/LuaManager.cpp
+++ b/QuackEngineSol/Src/LuaBridge/LuaManager.cpp
@@ -14,6 +14,12 @@ lua_State* readFileLua(std::string file)
 	lua_State* state = luaL_newstate();
 	std::string path = assets_path + "/lua/" + file;
 	
-	luaL_dofile(state, path.c_str());
+	int aux = luaL_dofile(state, path.c_str());
+	if (aux != 0) {
+		std::string msg = "ERROR: Calling luaL_dofile resulted in failure. Error: ";
+		std::string error = lua_tostring(state, -1);
+		throw(msg + error);
+	}
+
 	return state;
 }

--- a/QuackEngineSol/Src/QuackEngine/QuackEnginePro.cpp
+++ b/QuackEngineSol/Src/QuackEngine/QuackEnginePro.cpp
@@ -81,7 +81,6 @@ void QuackEnginePro::setup()
 	BulletQuack::Init();
 
 	SoundQuack::Init(assets_route);
-	//SoundQuack::Instance()->createSound("singing.wav", "singing");	sound test
 
 	FactoryManager::Init();
 
@@ -93,16 +92,17 @@ void QuackEnginePro::setup()
 	SceneMng::Init();
 
 	InputManager::Init();
-
-	//setFullScreen(true);
 }
 
 void QuackEnginePro::start(std::string route, std::string name)
 {
 	SceneMng::Instance()->loadScene(route, name);
-	//setFullScreen(true);
+
 	if (!updateStarted) {
 		quackTime_ = new QuackTime();
+
+		//SceneMng::Instance()->getCurrentScene()->createEntityByPrefab("Entities/entidad1.lua", "Mono2"); // TODO quitar esta prueba
+
 		update();
 	}
 }

--- a/QuackEngineSol/Src/QuackEngine/QuackEnginePro.cpp
+++ b/QuackEngineSol/Src/QuackEngine/QuackEnginePro.cpp
@@ -100,9 +100,6 @@ void QuackEnginePro::start(std::string route, std::string name)
 
 	if (!updateStarted) {
 		quackTime_ = new QuackTime();
-
-		//SceneMng::Instance()->getCurrentScene()->createEntityByPrefab("Entities/entidad1.lua", "Mono2"); // TODO quitar esta prueba
-
 		update();
 	}
 }

--- a/QuackEngineSol/Src/QuackEngine/Scene.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Scene.cpp
@@ -124,10 +124,8 @@ void Scene::addEntity(QuackEntity* e)
 	}
 }
 
-QuackEntity* Scene::createEntityByPrefab(const std::string& file, const std::string& name)
+void Scene::createEntityByPrefab(const std::string& file, const std::string& nameInFile, const std::string& nameInGame)
 {
-	QuackEntity* entity = new QuackEntity(name);
-
 	std::cout << "\n\n";
 
 	lua_State* state = nullptr;
@@ -138,30 +136,29 @@ QuackEntity* Scene::createEntityByPrefab(const std::string& file, const std::str
 	catch (std::string& error) {
 		std::cout << "ERROR: no se pudo leer el archivo " << file << "\n";
 		std::cout << error << '\n';
-		return nullptr;
+		return;
 	}
 	if (state == nullptr) {
 		std::cout << "ERROR: no se pudo leer el archivo " << file << "\n";
-		return nullptr;
+		return;
 	}
 
 	LuaRef refEntity = NULL;
 	try {
-		refEntity = readElementFromFile(state, name);
+		refEntity = readElementFromFile(state, nameInFile);
 	}
 	catch (...) {
 		std::cout << "ERROR: no se pudo cargar la entidad del archivo " << file << "\n";
-		return nullptr;
+		return;
 	}
-	std::cout << "Cargando " << name << "\n";
+	std::cout << "Cargando " << nameInFile << "\n";
 
 	enableExceptions(refEntity);
-	if (!createEntity(name, refEntity))
-		std::cout << "ERROR: no se ha podido cargar la entidad: " << name;
+	if (!createEntity(nameInGame, refEntity))
+		std::cout << "ERROR: no se ha podido cargar la entidad: " << nameInFile;
 
 	std::cout << "\n\n";
-
-	return entity;
+	return;
 }
 
 void Scene::start() {

--- a/QuackEngineSol/Src/QuackEngine/Scene.h
+++ b/QuackEngineSol/Src/QuackEngine/Scene.h
@@ -39,7 +39,7 @@ public:
 
 	void addEntity(QuackEntity* e); 
 
-	QuackEntity* createEntityByPrefab(const std::string& file, const std::string& name);
+	void createEntityByPrefab(const std::string& file, const std::string& nameInFile, const std::string& nameInGame);
 
 	void start();
 

--- a/QuackEngineSol/Src/QuackEngine/Scene.h
+++ b/QuackEngineSol/Src/QuackEngine/Scene.h
@@ -39,6 +39,8 @@ public:
 
 	void addEntity(QuackEntity* e); 
 
+	QuackEntity* createEntityByPrefab(const std::string& file, const std::string& name);
+
 	void start();
 
 	void preUpdate();


### PR DESCRIPTION
Con el método createEntityByPrefab(file, nameInFile, nameInGame) se pueden crear entidades a partir de prefabs desde C++
- Devuelve void ya que el propio método ya añade la entidad a la escena actual.
- file: La ruta del archivo del prefab (ej.: "Entities/Mono.lua")
- nameInFile: El nombre de la entidad dentro del archivo .lua (ej.: "Mono1")
- nameInGame: El nombre que le quieras dar a la entidad dentro del juego, no deben repetirse para no causar problemas (ej.: "Mono" + i)

Ejemplo de un Prefab.lua:

``` lua
Mono = {
    Active = true,

    Components = {"Transform", "MeshRenderer"},

    Transform = {
        Position = {0,10,0},
        Scale = {1,1,1},
        Rotation = {0,0,0}
    },

    MeshRenderer = {
        Mesh = "Suzanne.mesh",
    }
}
```