### PR TITLE
Ahora se puede cambiar los tags por Lua

### DIFF
--- a/QuackEngineSol/Src/QuackEngine/QuackEntity.h
+++ b/QuackEngineSol/Src/QuackEngine/QuackEntity.h
@@ -53,6 +53,7 @@ public:
 
 	std::string& name() { return name_; }
 	std::string& tag() { return tag_; }
+	void setTag(std::string t) { tag_ = t; }
 	inline bool isActive() const { return enable_; }
 	inline void setActive(bool state) {
 		enable_ = state;

--- a/QuackEngineSol/Src/QuackEngine/Scene.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Scene.cpp
@@ -100,6 +100,11 @@ QuackEntity* Scene::createEntity(const std::string& entityName, LuaRef entInfo)
 	bool active = true;
 	bool correct = readVariable<bool>(entInfo, "Active", &active);
 	if(correct) entity->setActive(active);
+	
+	std::string tag;
+	correct = readVariable<std::string>(entInfo, "Tag", &tag);
+	if(correct) 
+		entity->setTag(tag);
 
 	addEntity(entity);
 

--- a/QuackEngineSol/Src/QuackEngine/Scene.cpp
+++ b/QuackEngineSol/Src/QuackEngine/Scene.cpp
@@ -101,7 +101,7 @@ QuackEntity* Scene::createEntity(const std::string& entityName, LuaRef entInfo)
 	bool correct = readVariable<bool>(entInfo, "Active", &active);
 	if(correct) entity->setActive(active);
 	
-	std::string tag;
+	std::string tag = "Default";
 	correct = readVariable<std::string>(entInfo, "Tag", &tag);
 	if(correct) 
 		entity->setTag(tag);


### PR DESCRIPTION
Poniendo en una entidad de lua lo siguiente:

Tag = mitag

Cambiará desde createEntity las tags (que por defecto son "Default") a "mitag".